### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.ComparisonTime.props
+++ b/props/LiveSplit.ComparisonTime.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.ComparisonTime.props
+++ b/props/LiveSplit.ComparisonTime.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.ComparisonTime/LiveSplit.ComparisonTime.csproj
+++ b/src/LiveSplit.ComparisonTime/LiveSplit.ComparisonTime.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="$(LsSrcPath)\UpdateManager\UpdateManager.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
@@ -251,5 +251,8 @@ public class ComparisonTime : IComponent
     {
     }
 
-    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
+    }
 }

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
@@ -69,8 +69,8 @@ public class ComparisonTime : IComponent
     private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
     {
         if (Settings.BackgroundColor.A > 0
-            || Settings.BackgroundGradient != GradientType.Plain
-            && Settings.BackgroundColor2.A > 0)
+            || (Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0))
         {
             var gradientBrush = new LinearGradientBrush(
                         new PointF(0, 0),
@@ -169,7 +169,10 @@ public class ComparisonTime : IComponent
     protected string GetNameValue(string comparison)
     {
         if (Settings.TimingMethod != "Current Timing Method")
+        {
             return $"{comparison} ({Settings.TimingMethod})";
+        }
+
         return comparison;
     }
 
@@ -179,33 +182,52 @@ public class ComparisonTime : IComponent
         {
             return state.Run.Last().Comparisons[comparison][timingMethod];
         }
+
         if (Settings.Type == TimeType.SplitTime)
         {
             if (state.CurrentPhase == TimerPhase.NotRunning)
+            {
                 return null;
+            }
+
             if (state.CurrentPhase == TimerPhase.Ended)
+            {
                 return state.Run.Last().Comparisons[comparison][timingMethod];
+            }
+
             return state.Run[state.CurrentSplitIndex].Comparisons[comparison][timingMethod];
         }
         // Settings.Type == TimeType.SegmentTime
         if (state.CurrentPhase == TimerPhase.NotRunning)
+        {
             return null;
+        }
 
         TimeSpan? currentSplitComparisonTime;
         if (state.CurrentPhase == TimerPhase.Ended)
+        {
             currentSplitComparisonTime = state.Run.Last().Comparisons[comparison][timingMethod];
+        }
         else
+        {
             currentSplitComparisonTime = state.Run[state.CurrentSplitIndex].Comparisons[comparison][timingMethod];
+        }
 
         var previousSplitIndex = state.CurrentSplitIndex - 1;
         if (state.CurrentPhase == TimerPhase.Ended)
+        {
             previousSplitIndex = state.Run.Count - 2;
+        }
 
         TimeSpan? previousSplitComparisonTime;
         if (previousSplitIndex < 0)
+        {
             previousSplitComparisonTime = TimeSpan.Zero;
+        }
         else
+        {
             previousSplitComparisonTime = state.Run[previousSplitIndex].Comparisons[comparison][timingMethod];
+        }
 
         return currentSplitComparisonTime - previousSplitComparisonTime;
     }
@@ -214,13 +236,19 @@ public class ComparisonTime : IComponent
     {
         var comparison = Settings.Comparison == "Current Comparison" ? state.CurrentComparison : Settings.Comparison;
         if (!state.Run.Comparisons.Contains(comparison))
+        {
             comparison = state.CurrentComparison;
+        }
 
         var timingMethod = state.CurrentTimingMethod;
         if (Settings.TimingMethod == "Real Time")
+        {
             timingMethod = TimingMethod.RealTime;
+        }
         else if (Settings.TimingMethod == "Game Time")
+        {
             timingMethod = TimingMethod.GameTime;
+        }
 
         InternalComponent.InformationName = InternalComponent.LongestString = GetNameValue(comparison);
         if (InternalComponent.InformationName != PreviousInformationName)
@@ -239,11 +267,20 @@ public class ComparisonTime : IComponent
         var isTimingMethodOverride = Settings.TimingMethod != "Current Timing Method";
 
         if (isComparisonOverride && isTimingMethodOverride)
+        {
             return $"Comparison Time ({Settings.Comparison}, {Settings.TimingMethod})";
+        }
+
         if (isComparisonOverride)
+        {
             return $"Comparison Time ({Settings.Comparison})";
+        }
+
         if (isTimingMethodOverride)
+        {
             return $"Comparison Time ({Settings.TimingMethod})";
+        }
+
         return "Comparison Time";
     }
 

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
@@ -213,7 +213,7 @@ public class ComparisonTime : IComponent
             currentSplitComparisonTime = state.Run[state.CurrentSplitIndex].Comparisons[comparison][timingMethod];
         }
 
-        var previousSplitIndex = state.CurrentSplitIndex - 1;
+        int previousSplitIndex = state.CurrentSplitIndex - 1;
         if (state.CurrentPhase == TimerPhase.Ended)
         {
             previousSplitIndex = state.Run.Count - 2;
@@ -234,13 +234,13 @@ public class ComparisonTime : IComponent
 
     public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
     {
-        var comparison = Settings.Comparison == "Current Comparison" ? state.CurrentComparison : Settings.Comparison;
+        string comparison = Settings.Comparison == "Current Comparison" ? state.CurrentComparison : Settings.Comparison;
         if (!state.Run.Comparisons.Contains(comparison))
         {
             comparison = state.CurrentComparison;
         }
 
-        var timingMethod = state.CurrentTimingMethod;
+        TimingMethod timingMethod = state.CurrentTimingMethod;
         if (Settings.TimingMethod == "Real Time")
         {
             timingMethod = TimingMethod.RealTime;
@@ -263,8 +263,8 @@ public class ComparisonTime : IComponent
 
     protected string GetComponentName()
     {
-        var isComparisonOverride = Settings.Comparison != "Current Comparison";
-        var isTimingMethodOverride = Settings.TimingMethod != "Current Timing Method";
+        bool isComparisonOverride = Settings.Comparison != "Current Comparison";
+        bool isTimingMethodOverride = Settings.TimingMethod != "Current Timing Method";
 
         if (isComparisonOverride && isTimingMethodOverride)
         {

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
@@ -1,255 +1,255 @@
-﻿using LiveSplit.Model;
-using LiveSplit.Model.Comparisons;
-using LiveSplit.TimeFormatters;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Windows.Forms;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+using LiveSplit.TimeFormatters;
+
+namespace LiveSplit.UI.Components;
+
+public class ComparisonTime : IComponent
 {
-    public class ComparisonTime : IComponent
+    protected InfoTimeComponent InternalComponent { get; set; }
+    public ComparisonTimeSettings Settings { get; set; }
+    private SplitTimeFormatter Formatter { get; set; }
+    private string PreviousInformationName { get; set; }
+
+    public float PaddingTop => InternalComponent.PaddingTop;
+    public float PaddingLeft => InternalComponent.PaddingLeft;
+    public float PaddingBottom => InternalComponent.PaddingBottom;
+    public float PaddingRight => InternalComponent.PaddingRight;
+    public float VerticalHeight => InternalComponent.VerticalHeight;
+    public float MinimumWidth => InternalComponent.MinimumWidth;
+    public float HorizontalWidth => InternalComponent.HorizontalWidth;
+    public float MinimumHeight => InternalComponent.MinimumHeight;
+
+    public string ComponentName => GetComponentName();
+
+    public IDictionary<string, Action> ContextMenuControls => null;
+
+    public ComparisonTime(LiveSplitState state)
     {
-        protected InfoTimeComponent InternalComponent { get; set; }
-        public ComparisonTimeSettings Settings { get; set; }
-        private SplitTimeFormatter Formatter { get; set; }
-        private string PreviousInformationName { get; set; }
-
-        public float PaddingTop => InternalComponent.PaddingTop;
-        public float PaddingLeft => InternalComponent.PaddingLeft;
-        public float PaddingBottom => InternalComponent.PaddingBottom;
-        public float PaddingRight => InternalComponent.PaddingRight;
-        public float VerticalHeight => InternalComponent.VerticalHeight;
-        public float MinimumWidth => InternalComponent.MinimumWidth;
-        public float HorizontalWidth => InternalComponent.HorizontalWidth;
-        public float MinimumHeight => InternalComponent.MinimumHeight;
-
-        public string ComponentName => GetComponentName();
-
-        public IDictionary<string, Action> ContextMenuControls => null; 
-
-        public ComparisonTime(LiveSplitState state)
+        Settings = new ComparisonTimeSettings()
         {
-            Settings = new ComparisonTimeSettings()
-            {
-                CurrentState = state
-            };
-            Formatter = new SplitTimeFormatter(Settings.Accuracy);
-            InternalComponent = new InfoTimeComponent(null, null, Formatter);
-            state.ComparisonRenamed += state_ComparisonRenamed;
+            CurrentState = state
+        };
+        Formatter = new SplitTimeFormatter(Settings.Accuracy);
+        InternalComponent = new InfoTimeComponent(null, null, Formatter);
+        state.ComparisonRenamed += state_ComparisonRenamed;
+    }
+
+    void state_ComparisonRenamed(object sender, EventArgs e)
+    {
+        var args = (RenameEventArgs)e;
+        if (Settings.Comparison == args.OldName)
+        {
+            Settings.Comparison = args.NewName;
+            ((LiveSplitState)sender).Layout.HasChanged = true;
         }
+    }
 
-        void state_ComparisonRenamed(object sender, EventArgs e)
+    private void PrepareDraw(LiveSplitState state)
+    {
+        InternalComponent.DisplayTwoRows = Settings.Display2Rows;
+
+        InternalComponent.NameLabel.HasShadow
+            = InternalComponent.ValueLabel.HasShadow
+            = state.LayoutSettings.DropShadows;
+
+        Formatter.Accuracy = Settings.Accuracy;
+
+        InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
+        InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
+    }
+
+    private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
+    {
+        if (Settings.BackgroundColor.A > 0
+            || Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0)
         {
-            var args = (RenameEventArgs)e;
-            if (Settings.Comparison == args.OldName)
-            {
-                Settings.Comparison = args.NewName;
-                ((LiveSplitState)sender).Layout.HasChanged = true;
-            }
+            var gradientBrush = new LinearGradientBrush(
+                        new PointF(0, 0),
+                        Settings.BackgroundGradient == GradientType.Horizontal
+                        ? new PointF(width, 0)
+                        : new PointF(0, height),
+                        Settings.BackgroundColor,
+                        Settings.BackgroundGradient == GradientType.Plain
+                        ? Settings.BackgroundColor
+                        : Settings.BackgroundColor2);
+            g.FillRectangle(gradientBrush, 0, 0, width, height);
         }
+    }
 
-        private void PrepareDraw(LiveSplitState state)
+    public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
+    {
+        DrawBackground(g, state, width, VerticalHeight);
+        PrepareDraw(state);
+        InternalComponent.DrawVertical(g, state, width, clipRegion);
+    }
+
+    public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
+    {
+        DrawBackground(g, state, HorizontalWidth, height);
+        PrepareDraw(state);
+        InternalComponent.DrawHorizontal(g, state, height, clipRegion);
+    }
+
+    public Control GetSettingsControl(LayoutMode mode)
+    {
+        Settings.Mode = mode;
+        return Settings;
+    }
+
+    public void SetSettings(System.Xml.XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+    public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+    protected void SetAlternateText(string comparison)
+    {
+        switch (comparison)
         {
-            InternalComponent.DisplayTwoRows = Settings.Display2Rows;
-
-            InternalComponent.NameLabel.HasShadow 
-                = InternalComponent.ValueLabel.HasShadow
-                = state.LayoutSettings.DropShadows;
-
-            Formatter.Accuracy = Settings.Accuracy;
-
-            InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
-            InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
+            case Run.PersonalBestComparisonName:
+                InternalComponent.AlternateNameText = new[]
+                {
+                    "PB",
+                };
+                break;
+            case AverageSegmentsComparisonGenerator.ComparisonName:
+                InternalComponent.AlternateNameText = new[]
+                {
+                    AverageSegmentsComparisonGenerator.ShortComparisonName,
+                };
+                break;
+            case BestSegmentsComparisonGenerator.ComparisonName:
+                InternalComponent.AlternateNameText = new[]
+                {
+                    BestSegmentsComparisonGenerator.ShortComparisonName,
+                };
+                break;
+            case LatestRunComparisonGenerator.ComparisonName:
+                InternalComponent.AlternateNameText = new[]
+                {
+                    LatestRunComparisonGenerator.ShortComparisonName,
+                };
+                break;
+            case MedianSegmentsComparisonGenerator.ComparisonName:
+                InternalComponent.AlternateNameText = new[]
+                {
+                    MedianSegmentsComparisonGenerator.ShortComparisonName,
+                };
+                break;
+            case PercentileComparisonGenerator.ComparisonName:
+                InternalComponent.AlternateNameText = new[]
+                {
+                    PercentileComparisonGenerator.ShortComparisonName,
+                };
+                break;
+            case WorstSegmentsComparisonGenerator.ComparisonName:
+                InternalComponent.AlternateNameText = new[]
+                {
+                    WorstSegmentsComparisonGenerator.ShortComparisonName,
+                };
+                break;
+            default:
+                break;
         }
+    }
 
-        private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
+    protected string GetNameValue(string comparison)
+    {
+        if (Settings.TimingMethod != "Current Timing Method")
+            return $"{comparison} ({Settings.TimingMethod})";
+        return comparison;
+    }
+
+    protected TimeSpan? GetTimeValue(LiveSplitState state, string comparison, TimingMethod timingMethod)
+    {
+        if (Settings.Type == TimeType.FinalTime)
         {
-            if (Settings.BackgroundColor.A > 0
-                || Settings.BackgroundGradient != GradientType.Plain
-                && Settings.BackgroundColor2.A > 0)
-            {
-                var gradientBrush = new LinearGradientBrush(
-                            new PointF(0, 0),
-                            Settings.BackgroundGradient == GradientType.Horizontal
-                            ? new PointF(width, 0)
-                            : new PointF(0, height),
-                            Settings.BackgroundColor,
-                            Settings.BackgroundGradient == GradientType.Plain
-                            ? Settings.BackgroundColor
-                            : Settings.BackgroundColor2);
-                g.FillRectangle(gradientBrush, 0, 0, width, height);
-            }
+            return state.Run.Last().Comparisons[comparison][timingMethod];
         }
-
-        public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
+        if (Settings.Type == TimeType.SplitTime)
         {
-            DrawBackground(g, state, width, VerticalHeight);
-            PrepareDraw(state);
-            InternalComponent.DrawVertical(g, state, width, clipRegion);
-        }
-
-        public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
-        {
-            DrawBackground(g, state, HorizontalWidth, height);
-            PrepareDraw(state);
-            InternalComponent.DrawHorizontal(g, state, height, clipRegion);
-        }
-
-        public Control GetSettingsControl(LayoutMode mode)
-        {
-            Settings.Mode = mode;
-            return Settings;
-        }
-
-        public void SetSettings(System.Xml.XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-        public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        protected void SetAlternateText(string comparison)
-        {
-            switch (comparison)
-            {
-                case Run.PersonalBestComparisonName:
-                    InternalComponent.AlternateNameText = new[]
-                    {
-                        "PB",
-                    };
-                    break;
-                case AverageSegmentsComparisonGenerator.ComparisonName:
-                    InternalComponent.AlternateNameText = new[]
-                    {
-                        AverageSegmentsComparisonGenerator.ShortComparisonName,
-                    };
-                    break;
-                case BestSegmentsComparisonGenerator.ComparisonName:
-                    InternalComponent.AlternateNameText = new[]
-                    {
-                        BestSegmentsComparisonGenerator.ShortComparisonName,
-                    };
-                    break;
-                case LatestRunComparisonGenerator.ComparisonName:
-                    InternalComponent.AlternateNameText = new[]
-                    {
-                        LatestRunComparisonGenerator.ShortComparisonName,
-                    };
-                    break;
-                case MedianSegmentsComparisonGenerator.ComparisonName:
-                    InternalComponent.AlternateNameText = new[]
-                    {
-                        MedianSegmentsComparisonGenerator.ShortComparisonName,
-                    };
-                    break;
-                case PercentileComparisonGenerator.ComparisonName:
-                    InternalComponent.AlternateNameText = new[]
-                    {
-                        PercentileComparisonGenerator.ShortComparisonName,
-                    };
-                    break;
-                case WorstSegmentsComparisonGenerator.ComparisonName:
-                    InternalComponent.AlternateNameText = new[]
-                    {
-                        WorstSegmentsComparisonGenerator.ShortComparisonName,
-                    };
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        protected string GetNameValue(string comparison)
-        {
-            if (Settings.TimingMethod != "Current Timing Method")
-                return $"{comparison} ({Settings.TimingMethod})";
-            return comparison;
-        }
-
-        protected TimeSpan? GetTimeValue(LiveSplitState state, string comparison, TimingMethod timingMethod)
-        {
-            if (Settings.Type == TimeType.FinalTime)
-            {
-                return state.Run.Last().Comparisons[comparison][timingMethod];
-            }
-            if (Settings.Type == TimeType.SplitTime)
-            {
-                if (state.CurrentPhase == TimerPhase.NotRunning)
-                    return null;
-                if (state.CurrentPhase == TimerPhase.Ended)
-                    return state.Run.Last().Comparisons[comparison][timingMethod];
-                return state.Run[state.CurrentSplitIndex].Comparisons[comparison][timingMethod];
-            }
-            // Settings.Type == TimeType.SegmentTime
             if (state.CurrentPhase == TimerPhase.NotRunning)
                 return null;
-
-            TimeSpan? currentSplitComparisonTime;
             if (state.CurrentPhase == TimerPhase.Ended)
-                currentSplitComparisonTime = state.Run.Last().Comparisons[comparison][timingMethod];
-            else
-                currentSplitComparisonTime = state.Run[state.CurrentSplitIndex].Comparisons[comparison][timingMethod];
-
-            var previousSplitIndex = state.CurrentSplitIndex - 1;
-            if (state.CurrentPhase == TimerPhase.Ended)
-                previousSplitIndex = state.Run.Count - 2;
-
-            TimeSpan? previousSplitComparisonTime;
-            if (previousSplitIndex < 0)
-                previousSplitComparisonTime = TimeSpan.Zero;
-            else
-                previousSplitComparisonTime = state.Run[previousSplitIndex].Comparisons[comparison][timingMethod];
-
-            return currentSplitComparisonTime - previousSplitComparisonTime;
+                return state.Run.Last().Comparisons[comparison][timingMethod];
+            return state.Run[state.CurrentSplitIndex].Comparisons[comparison][timingMethod];
         }
+        // Settings.Type == TimeType.SegmentTime
+        if (state.CurrentPhase == TimerPhase.NotRunning)
+            return null;
 
-        public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
-        {
-            var comparison = Settings.Comparison == "Current Comparison" ? state.CurrentComparison : Settings.Comparison;
-            if (!state.Run.Comparisons.Contains(comparison))
-                comparison = state.CurrentComparison;
+        TimeSpan? currentSplitComparisonTime;
+        if (state.CurrentPhase == TimerPhase.Ended)
+            currentSplitComparisonTime = state.Run.Last().Comparisons[comparison][timingMethod];
+        else
+            currentSplitComparisonTime = state.Run[state.CurrentSplitIndex].Comparisons[comparison][timingMethod];
 
-            var timingMethod = state.CurrentTimingMethod;
-            if (Settings.TimingMethod == "Real Time")
-                timingMethod = TimingMethod.RealTime;
-            else if (Settings.TimingMethod == "Game Time")
-                timingMethod = TimingMethod.GameTime;
+        var previousSplitIndex = state.CurrentSplitIndex - 1;
+        if (state.CurrentPhase == TimerPhase.Ended)
+            previousSplitIndex = state.Run.Count - 2;
 
-            InternalComponent.InformationName = InternalComponent.LongestString = GetNameValue(comparison);
-            if (InternalComponent.InformationName != PreviousInformationName)
-            {
-                SetAlternateText(comparison);
-                PreviousInformationName = InternalComponent.InformationName;
-            }
+        TimeSpan? previousSplitComparisonTime;
+        if (previousSplitIndex < 0)
+            previousSplitComparisonTime = TimeSpan.Zero;
+        else
+            previousSplitComparisonTime = state.Run[previousSplitIndex].Comparisons[comparison][timingMethod];
 
-            InternalComponent.TimeValue = GetTimeValue(state, comparison, timingMethod);
-            InternalComponent.Update(invalidator, state, width, height, mode);
-        }
-
-        protected string GetComponentName()
-        {
-            var isComparisonOverride = Settings.Comparison != "Current Comparison";
-            var isTimingMethodOverride = Settings.TimingMethod != "Current Timing Method";
-
-            if (isComparisonOverride && isTimingMethodOverride)
-                return $"Comparison Time ({Settings.Comparison}, {Settings.TimingMethod})";
-            if (isComparisonOverride)
-                return $"Comparison Time ({Settings.Comparison})";
-            if (isTimingMethodOverride)
-                return $"Comparison Time ({Settings.TimingMethod})";
-            return "Comparison Time";
-        }
-
-        public void Dispose()
-        {
-        }
-
-        public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+        return currentSplitComparisonTime - previousSplitComparisonTime;
     }
+
+    public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+        var comparison = Settings.Comparison == "Current Comparison" ? state.CurrentComparison : Settings.Comparison;
+        if (!state.Run.Comparisons.Contains(comparison))
+            comparison = state.CurrentComparison;
+
+        var timingMethod = state.CurrentTimingMethod;
+        if (Settings.TimingMethod == "Real Time")
+            timingMethod = TimingMethod.RealTime;
+        else if (Settings.TimingMethod == "Game Time")
+            timingMethod = TimingMethod.GameTime;
+
+        InternalComponent.InformationName = InternalComponent.LongestString = GetNameValue(comparison);
+        if (InternalComponent.InformationName != PreviousInformationName)
+        {
+            SetAlternateText(comparison);
+            PreviousInformationName = InternalComponent.InformationName;
+        }
+
+        InternalComponent.TimeValue = GetTimeValue(state, comparison, timingMethod);
+        InternalComponent.Update(invalidator, state, width, height, mode);
+    }
+
+    protected string GetComponentName()
+    {
+        var isComparisonOverride = Settings.Comparison != "Current Comparison";
+        var isTimingMethodOverride = Settings.TimingMethod != "Current Timing Method";
+
+        if (isComparisonOverride && isTimingMethodOverride)
+            return $"Comparison Time ({Settings.Comparison}, {Settings.TimingMethod})";
+        if (isComparisonOverride)
+            return $"Comparison Time ({Settings.Comparison})";
+        if (isTimingMethodOverride)
+            return $"Comparison Time ({Settings.TimingMethod})";
+        return "Comparison Time";
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
 }

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTime.cs
@@ -42,7 +42,7 @@ public class ComparisonTime : IComponent
         state.ComparisonRenamed += state_ComparisonRenamed;
     }
 
-    void state_ComparisonRenamed(object sender, EventArgs e)
+    private void state_ComparisonRenamed(object sender, EventArgs e)
     {
         var args = (RenameEventArgs)e;
         if (Settings.Comparison == args.OldName)

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeFactory.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeFactory.cs
@@ -1,27 +1,27 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(ComparisonTimeFactory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class ComparisonTimeFactory : IComponentFactory
 {
-    public class ComparisonTimeFactory : IComponentFactory
-    {
-        public string ComponentName => "Comparison Time";
+    public string ComponentName => "Comparison Time";
 
-        public string Description => "Displays the final time (or a split time/segment time) from a particular comparison.";
+    public string Description => "Displays the final time (or a split time/segment time) from a particular comparison.";
 
-        public ComponentCategory Category => ComponentCategory.Information;
+    public ComponentCategory Category => ComponentCategory.Information;
 
-        public IComponent Create(LiveSplitState state) => new ComparisonTime(state);
+    public IComponent Create(LiveSplitState state) => new ComparisonTime(state);
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.ComparisonTime.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.ComparisonTime.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
-    }
+    public Version Version => Version.Parse("1.8.29");
 }

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeFactory.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeFactory.cs
@@ -15,7 +15,10 @@ public class ComparisonTimeFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Information;
 
-    public IComponent Create(LiveSplitState state) => new ComparisonTime(state);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new ComparisonTime(state);
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
@@ -95,7 +95,7 @@ public partial class ComparisonTimeSettings : UserControl
         chkOverrideTimeColor_CheckedChanged(null, null);
         cmbComparison.Items.Clear();
         cmbComparison.Items.Add("Current Comparison");
-        cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
+        cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x is not BestSplitTimesComparisonGenerator.ComparisonName and not NoneComparisonGenerator.ComparisonName).ToArray());
         if (!cmbComparison.Items.Contains(Comparison))
         {
             cmbComparison.Items.Add(Comparison);

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
@@ -1,235 +1,235 @@
-﻿using LiveSplit.Model;
-using LiveSplit.Model.Comparisons;
-using LiveSplit.TimeFormatters;
-using System;
+﻿using System;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+using LiveSplit.TimeFormatters;
+
+namespace LiveSplit.UI.Components;
+
+public partial class ComparisonTimeSettings : UserControl
 {
-    public partial class ComparisonTimeSettings : UserControl
+    public Color TextColor { get; set; }
+    public bool OverrideTextColor { get; set; }
+    public Color TimeColor { get; set; }
+    public bool OverrideTimeColor { get; set; }
+    public TimeAccuracy Accuracy { get; set; }
+
+    public Color BackgroundColor { get; set; }
+    public Color BackgroundColor2 { get; set; }
+    public GradientType BackgroundGradient { get; set; }
+    public string GradientString
     {
-        public Color TextColor { get; set; }
-        public bool OverrideTextColor { get; set; }
-        public Color TimeColor { get; set; }
-        public bool OverrideTimeColor { get; set; }
-        public TimeAccuracy Accuracy { get; set; }
+        get { return BackgroundGradient.ToString(); }
+        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+    }
 
-        public Color BackgroundColor { get; set; }
-        public Color BackgroundColor2 { get; set; }
-        public GradientType BackgroundGradient { get; set; }
-        public string GradientString
+    public string Comparison { get; set; }
+    public string TimingMethod { get; set; }
+    public LiveSplitState CurrentState { get; set; }
+    public bool Display2Rows { get; set; }
+
+    public TimeType Type { get; set; }
+
+    public LayoutMode Mode { get; set; }
+
+    public ComparisonTimeSettings()
+    {
+        InitializeComponent();
+
+        TextColor = Color.FromArgb(255, 255, 255);
+        OverrideTextColor = false;
+        TimeColor = Color.FromArgb(255, 255, 255);
+        OverrideTimeColor = false;
+        Accuracy = TimeAccuracy.Seconds;
+        BackgroundColor = Color.Transparent;
+        BackgroundColor2 = Color.Transparent;
+        BackgroundGradient = GradientType.Plain;
+        Comparison = "Current Comparison";
+        TimingMethod = "Current Timing Method";
+        Display2Rows = false;
+        Type = TimeType.FinalTime;
+
+        chkOverrideTextColor.DataBindings.Add("Checked", this, "OverrideTextColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnTextColor.DataBindings.Add("BackColor", this, "TextColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkOverrideTimeColor.DataBindings.Add("Checked", this, "OverrideTimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnTimeColor.DataBindings.Add("BackColor", this, "TimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
+
+        cmbGradientType.SelectedIndexChanged += cmbGradientType_SelectedIndexChanged;
+        cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbComparison.SelectedIndexChanged += cmbComparison_SelectedIndexChanged;
+        cmbComparison.DataBindings.Add("SelectedItem", this, "Comparison", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
+
+        rdoSeconds.CheckedChanged += rdoSeconds_CheckedChanged;
+        rdoTenths.CheckedChanged += rdoTenths_CheckedChanged;
+        rdoHundredths.CheckedChanged += rdoHundredths_CheckedChanged;
+
+        chkOverrideTextColor.CheckedChanged += chkOverrideTextColor_CheckedChanged;
+        chkOverrideTimeColor.CheckedChanged += chkOverrideTimeColor_CheckedChanged;
+    }
+
+    void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+    {
+        label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
+    }
+
+    void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
+    {
+        label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
+    }
+    void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        Comparison = cmbComparison.SelectedItem.ToString();
+    }
+
+    void ComparisonTimeSettings_Load(object sender, EventArgs e)
+    {
+        chkOverrideTextColor_CheckedChanged(null, null);
+        chkOverrideTimeColor_CheckedChanged(null, null);
+        cmbComparison.Items.Clear();
+        cmbComparison.Items.Add("Current Comparison");
+        cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
+        if (!cmbComparison.Items.Contains(Comparison))
+            cmbComparison.Items.Add(Comparison);
+        rdoSeconds.Checked = Accuracy == TimeAccuracy.Seconds;
+        rdoTenths.Checked = Accuracy == TimeAccuracy.Tenths;
+        rdoHundredths.Checked = Accuracy == TimeAccuracy.Hundredths;
+        rdoTypeFinalTime.Checked = Type == TimeType.FinalTime;
+        rdoTypeSplitTime.Checked = Type == TimeType.SplitTime;
+        rdoTypeSegmentTime.Checked = Type == TimeType.SegmentTime;
+        if (Mode == LayoutMode.Horizontal)
         {
-            get { return BackgroundGradient.ToString(); }
-            set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+            chkTwoRows.Enabled = false;
+            chkTwoRows.DataBindings.Clear();
+            chkTwoRows.Checked = true;
         }
-
-        public string Comparison { get; set; }
-        public string TimingMethod { get; set; }
-        public LiveSplitState CurrentState { get; set; }
-        public bool Display2Rows { get; set; }
-
-        public TimeType Type { get; set; }
-
-        public LayoutMode Mode { get; set; }
-
-        public ComparisonTimeSettings()
+        else
         {
-            InitializeComponent();
+            chkTwoRows.Enabled = true;
+            chkTwoRows.DataBindings.Clear();
+            chkTwoRows.DataBindings.Add("Checked", this, "Display2Rows", false, DataSourceUpdateMode.OnPropertyChanged);
+        }
+    }
 
-            TextColor = Color.FromArgb(255, 255, 255);
-            OverrideTextColor = false;
-            TimeColor = Color.FromArgb(255, 255, 255);
-            OverrideTimeColor = false;
+    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
+        btnColor2.DataBindings.Clear();
+        btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        GradientString = cmbGradientType.SelectedItem.ToString();
+    }
+
+    void rdoHundredths_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateAccuracy();
+    }
+
+    void rdoTenths_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateAccuracy();
+    }
+
+    void rdoSeconds_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateAccuracy();
+    }
+
+    void UpdateAccuracy()
+    {
+        if (rdoSeconds.Checked)
             Accuracy = TimeAccuracy.Seconds;
-            BackgroundColor = Color.Transparent;
-            BackgroundColor2 = Color.Transparent;
-            BackgroundGradient = GradientType.Plain;
-            Comparison = "Current Comparison";
-            TimingMethod = "Current Timing Method";
-            Display2Rows = false;
+        else if (rdoTenths.Checked)
+            Accuracy = TimeAccuracy.Tenths;
+        else if (rdoHundredths.Checked)
+            Accuracy = TimeAccuracy.Hundredths;
+        else
+            Accuracy = TimeAccuracy.Milliseconds;
+    }
+
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+        TextColor = SettingsHelper.ParseColor(element["TextColor"]);
+        OverrideTextColor = SettingsHelper.ParseBool(element["OverrideTextColor"]);
+        TimeColor = SettingsHelper.ParseColor(element["TimeColor"]);
+        OverrideTimeColor = SettingsHelper.ParseBool(element["OverrideTimeColor"]);
+        Accuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["Accuracy"]);
+        BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"]);
+        BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"]);
+        GradientString = SettingsHelper.ParseString(element["BackgroundGradient"]);
+        Comparison = SettingsHelper.ParseString(element["Comparison"]);
+        TimingMethod = SettingsHelper.ParseString(element["TimingMethod"], "Current Timing Method");
+        Display2Rows = SettingsHelper.ParseBool(element["Display2Rows"], false);
+        Type = SettingsHelper.ParseEnum<TimeType>(element["Type"]);
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
+
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
+
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.4") ^
+        SettingsHelper.CreateSetting(document, parent, "TextColor", TextColor) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTextColor", OverrideTextColor) ^
+        SettingsHelper.CreateSetting(document, parent, "TimeColor", TimeColor) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTimeColor", OverrideTimeColor) ^
+        SettingsHelper.CreateSetting(document, parent, "Accuracy", Accuracy) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
+        SettingsHelper.CreateSetting(document, parent, "Comparison", Comparison) ^
+        SettingsHelper.CreateSetting(document, parent, "TimingMethod", TimingMethod) ^
+        SettingsHelper.CreateSetting(document, parent, "Display2Rows", Display2Rows) ^
+        SettingsHelper.CreateSetting(document, parent, "Type", Type);
+    }
+
+    private void ColorButtonClick(object sender, EventArgs e)
+    {
+        SettingsHelper.ColorButtonClick((Button)sender, this);
+    }
+
+    private void rdoTypeFinalTime_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateTimeType();
+    }
+
+    private void rdoTypeSplitTime_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateTimeType();
+    }
+
+    private void UpdateTimeType()
+    {
+        if (rdoTypeFinalTime.Checked)
+        {
             Type = TimeType.FinalTime;
-
-            chkOverrideTextColor.DataBindings.Add("Checked", this, "OverrideTextColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnTextColor.DataBindings.Add("BackColor", this, "TextColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkOverrideTimeColor.DataBindings.Add("Checked", this, "OverrideTimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnTimeColor.DataBindings.Add("BackColor", this, "TimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
-
-            cmbGradientType.SelectedIndexChanged += cmbGradientType_SelectedIndexChanged;
-            cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbComparison.SelectedIndexChanged += cmbComparison_SelectedIndexChanged;
-            cmbComparison.DataBindings.Add("SelectedItem", this, "Comparison", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
-
-            rdoSeconds.CheckedChanged += rdoSeconds_CheckedChanged;
-            rdoTenths.CheckedChanged += rdoTenths_CheckedChanged;
-            rdoHundredths.CheckedChanged += rdoHundredths_CheckedChanged;
-
-            chkOverrideTextColor.CheckedChanged += chkOverrideTextColor_CheckedChanged;
-            chkOverrideTimeColor.CheckedChanged += chkOverrideTimeColor_CheckedChanged;
+            return;
         }
-
-        void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+        if (rdoTypeSplitTime.Checked)
         {
-            label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
+            Type = TimeType.SplitTime;
+            return;
         }
+        Type = TimeType.SegmentTime;
+    }
 
-        void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
-        {
-            label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
-        }
-        void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            Comparison = cmbComparison.SelectedItem.ToString();
-        }
-
-        void ComparisonTimeSettings_Load(object sender, EventArgs e)
-        {
-            chkOverrideTextColor_CheckedChanged(null, null);
-            chkOverrideTimeColor_CheckedChanged(null, null);
-            cmbComparison.Items.Clear();
-            cmbComparison.Items.Add("Current Comparison");
-            cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
-            if (!cmbComparison.Items.Contains(Comparison))
-                cmbComparison.Items.Add(Comparison);
-            rdoSeconds.Checked = Accuracy == TimeAccuracy.Seconds;
-            rdoTenths.Checked = Accuracy == TimeAccuracy.Tenths;
-            rdoHundredths.Checked = Accuracy == TimeAccuracy.Hundredths;
-            rdoTypeFinalTime.Checked = Type == TimeType.FinalTime;
-            rdoTypeSplitTime.Checked = Type == TimeType.SplitTime;
-            rdoTypeSegmentTime.Checked = Type == TimeType.SegmentTime;
-            if (Mode == LayoutMode.Horizontal)
-            {
-                chkTwoRows.Enabled = false;
-                chkTwoRows.DataBindings.Clear();
-                chkTwoRows.Checked = true;
-            }
-            else
-            {
-                chkTwoRows.Enabled = true;
-                chkTwoRows.DataBindings.Clear();
-                chkTwoRows.DataBindings.Add("Checked", this, "Display2Rows", false, DataSourceUpdateMode.OnPropertyChanged);
-            }
-        }
-
-        void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
-            btnColor2.DataBindings.Clear();
-            btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            GradientString = cmbGradientType.SelectedItem.ToString();
-        }
-
-        void rdoHundredths_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateAccuracy();
-        }
-
-        void rdoTenths_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateAccuracy();
-        }
-
-        void rdoSeconds_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateAccuracy();
-        }
-
-        void UpdateAccuracy()
-        {
-            if (rdoSeconds.Checked)
-                Accuracy = TimeAccuracy.Seconds;
-            else if (rdoTenths.Checked)
-                Accuracy = TimeAccuracy.Tenths;
-            else if (rdoHundredths.Checked)
-                Accuracy = TimeAccuracy.Hundredths;
-            else
-                Accuracy = TimeAccuracy.Milliseconds;
-        }
-
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
-            TextColor = SettingsHelper.ParseColor(element["TextColor"]);
-            OverrideTextColor = SettingsHelper.ParseBool(element["OverrideTextColor"]);
-            TimeColor = SettingsHelper.ParseColor(element["TimeColor"]);
-            OverrideTimeColor = SettingsHelper.ParseBool(element["OverrideTimeColor"]);
-            Accuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["Accuracy"]);
-            BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"]);
-            BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"]);
-            GradientString = SettingsHelper.ParseString(element["BackgroundGradient"]);
-            Comparison = SettingsHelper.ParseString(element["Comparison"]);
-            TimingMethod = SettingsHelper.ParseString(element["TimingMethod"], "Current Timing Method");
-            Display2Rows = SettingsHelper.ParseBool(element["Display2Rows"], false);
-            Type = SettingsHelper.ParseEnum<TimeType>(element["Type"]);
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
-        }
-
-        public int GetSettingsHashCode()
-        {
-            return CreateSettingsNode(null, null);
-        }
-
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.4") ^
-            SettingsHelper.CreateSetting(document, parent, "TextColor", TextColor) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTextColor", OverrideTextColor) ^
-            SettingsHelper.CreateSetting(document, parent, "TimeColor", TimeColor) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTimeColor", OverrideTimeColor) ^
-            SettingsHelper.CreateSetting(document, parent, "Accuracy", Accuracy) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
-            SettingsHelper.CreateSetting(document, parent, "Comparison", Comparison) ^
-            SettingsHelper.CreateSetting(document, parent, "TimingMethod", TimingMethod) ^
-            SettingsHelper.CreateSetting(document, parent, "Display2Rows", Display2Rows) ^
-            SettingsHelper.CreateSetting(document, parent, "Type", Type);
-        }
-
-        private void ColorButtonClick(object sender, EventArgs e)
-        {
-            SettingsHelper.ColorButtonClick((Button)sender, this);
-        }
-
-        private void rdoTypeFinalTime_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateTimeType();
-        }
-
-        private void rdoTypeSplitTime_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateTimeType();
-        }
-
-        private void UpdateTimeType()
-        {
-            if (rdoTypeFinalTime.Checked)
-            {
-                Type = TimeType.FinalTime;
-                return;
-            }
-            if (rdoTypeSplitTime.Checked)
-            {
-                Type = TimeType.SplitTime;
-                return;
-            }
-            Type = TimeType.SegmentTime;
-        }
-
-        private void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            TimingMethod = cmbTimingMethod.SelectedItem.ToString();
-        }
+    private void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        TimingMethod = cmbTimingMethod.SelectedItem.ToString();
     }
 }

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
@@ -183,7 +183,7 @@ public partial class ComparisonTimeSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
@@ -23,8 +23,8 @@ public partial class ComparisonTimeSettings : UserControl
     public GradientType BackgroundGradient { get; set; }
     public string GradientString
     {
-        get { return BackgroundGradient.ToString(); }
-        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+        get => BackgroundGradient.ToString();
+        set => BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value);
     }
 
     public string Comparison { get; set; }

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
@@ -74,21 +74,22 @@ public partial class ComparisonTimeSettings : UserControl
         chkOverrideTimeColor.CheckedChanged += chkOverrideTimeColor_CheckedChanged;
     }
 
-    void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+    private void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
     {
         label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
     }
 
-    void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
+    private void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
     {
         label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
     }
-    void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
+
+    private void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
     {
         Comparison = cmbComparison.SelectedItem.ToString();
     }
 
-    void ComparisonTimeSettings_Load(object sender, EventArgs e)
+    private void ComparisonTimeSettings_Load(object sender, EventArgs e)
     {
         chkOverrideTextColor_CheckedChanged(null, null);
         chkOverrideTimeColor_CheckedChanged(null, null);
@@ -117,7 +118,7 @@ public partial class ComparisonTimeSettings : UserControl
         }
     }
 
-    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
     {
         btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
         btnColor2.DataBindings.Clear();
@@ -125,22 +126,22 @@ public partial class ComparisonTimeSettings : UserControl
         GradientString = cmbGradientType.SelectedItem.ToString();
     }
 
-    void rdoHundredths_CheckedChanged(object sender, EventArgs e)
+    private void rdoHundredths_CheckedChanged(object sender, EventArgs e)
     {
         UpdateAccuracy();
     }
 
-    void rdoTenths_CheckedChanged(object sender, EventArgs e)
+    private void rdoTenths_CheckedChanged(object sender, EventArgs e)
     {
         UpdateAccuracy();
     }
 
-    void rdoSeconds_CheckedChanged(object sender, EventArgs e)
+    private void rdoSeconds_CheckedChanged(object sender, EventArgs e)
     {
         UpdateAccuracy();
     }
 
-    void UpdateAccuracy()
+    private void UpdateAccuracy()
     {
         if (rdoSeconds.Checked)
             Accuracy = TimeAccuracy.Seconds;

--- a/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/ComparisonTimeSettings.cs
@@ -97,7 +97,10 @@ public partial class ComparisonTimeSettings : UserControl
         cmbComparison.Items.Add("Current Comparison");
         cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
         if (!cmbComparison.Items.Contains(Comparison))
+        {
             cmbComparison.Items.Add(Comparison);
+        }
+
         rdoSeconds.Checked = Accuracy == TimeAccuracy.Seconds;
         rdoTenths.Checked = Accuracy == TimeAccuracy.Tenths;
         rdoHundredths.Checked = Accuracy == TimeAccuracy.Hundredths;
@@ -144,13 +147,21 @@ public partial class ComparisonTimeSettings : UserControl
     private void UpdateAccuracy()
     {
         if (rdoSeconds.Checked)
+        {
             Accuracy = TimeAccuracy.Seconds;
+        }
         else if (rdoTenths.Checked)
+        {
             Accuracy = TimeAccuracy.Tenths;
+        }
         else if (rdoHundredths.Checked)
+        {
             Accuracy = TimeAccuracy.Hundredths;
+        }
         else
+        {
             Accuracy = TimeAccuracy.Milliseconds;
+        }
     }
 
     public void SetSettings(XmlNode node)
@@ -221,11 +232,13 @@ public partial class ComparisonTimeSettings : UserControl
             Type = TimeType.FinalTime;
             return;
         }
+
         if (rdoTypeSplitTime.Checked)
         {
             Type = TimeType.SplitTime;
             return;
         }
+
         Type = TimeType.SegmentTime;
     }
 

--- a/src/LiveSplit.ComparisonTime/UI/Components/TimeType.cs
+++ b/src/LiveSplit.ComparisonTime/UI/Components/TimeType.cs
@@ -1,9 +1,8 @@
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public enum TimeType
 {
-    public enum TimeType
-    {
-        FinalTime,
-        SplitTime,
-        SegmentTime,
-    }
+    FinalTime,
+    SplitTime,
+    SegmentTime,
 }


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
